### PR TITLE
fix for mojolicious8

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use ExtUtils::MakeMaker;
 
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
-my $module_file = 'lib/Mojolicious/Command/generate/resources.pm';
+my $module_file = 'lib/Mojolicious/Command/Author/generate/resources.pm';
 my $preop       = qq'pod2text $module_file > README;'
   . qq'pod2markdown $module_file > README.md';
 WriteMakefile(
@@ -11,9 +11,9 @@ WriteMakefile(
   VERSION_FROM  => $module_file,                               # finds \$VERSION
   AUTHOR        => 'Красимир Беров (berov@cpan.org)',
   ABSTRACT_FROM => $module_file,
-  PREREQ_PM => {'Mojolicious' => '7.60', perl => '5.020001'},
+  PREREQ_PM => {'Mojolicious' => '8.0', perl => '5.020001'},
   TEST_REQUIRES =>
-    {'Mojo::SQLite' => '3.000', 'Mojolicious::Plugin::OpenAPI' => '1.25'},
+    {'Mojo::SQLite' => '3.000', 'Mojolicious::Plugin::OpenAPI' => '2.00'},
   test       => {TESTS => 't/*.t'},
   clean      => {FILES => 'Mojolicious-Command-*'},
   dist       => {PREOP => $preop},

--- a/lib/Mojolicious/Command/Author/generate/resources.pm
+++ b/lib/Mojolicious/Command/Author/generate/resources.pm
@@ -1,4 +1,4 @@
-package Mojolicious::Command::generate::resources;
+package Mojolicious::Command::Author::generate::resources;
 use Mojo::Base 'Mojolicious::Command', -signatures;
 
 use Mojo::Util qw(class_to_path decamelize camelize getopt);

--- a/t/002_crud.t
+++ b/t/002_crud.t
@@ -13,7 +13,7 @@ my $buffer = '';
   my $commands = Mojolicious::Commands->new;
   open my $handle, '>', \$buffer;
   local *STDOUT = $handle;
-  $commands->run('help', 'generate', 'resources');
+  $commands->run('generate', 'help', 'resources');
 }
 like $buffer, qr/Usage: APPLICATION generate resources \[OPTIONS\]/,
   'right help output';
@@ -41,7 +41,7 @@ like $buffer, qr/Usage: APPLICATION generate resources \[OPTIONS\]/,
   local *STDOUT = $handle;
   my $blog = Blog->new;
   push @{$blog->renderer->paths}, $blog->home->rel_file('resources_templates');
-  my $cm = Mojolicious::Command::generate::resources->new(app => $blog)
+  my $cm = Mojolicious::Command::Author::generate::resources->new(app => $blog)
     ->run('-t' => 'users,groups');
   like($buffer,
        qr|\[exist\].+?lib.+Controller|,
@@ -84,7 +84,7 @@ like $buffer, qr/Usage: APPLICATION generate resources \[OPTIONS\]/,
   my $blog = $test->app;
 
 # Generate new routes and helpers for the instantiated application.
-  my $cm = Mojolicious::Command::generate::resources->new(app => $blog);
+  my $cm = Mojolicious::Command::Author::generate::resources->new(app => $blog);
   $cm->args->{tables} = [qw(groups users)];
   my $app_routes = $blog->routes;
   for my $r (@{$cm->routes}) {


### PR DESCRIPTION
This is a fix for Mojolicious 8. In that version all the 'generate' subcommands moved to the Mojolicious::Command::Author:: namespace.

Currently 003_openapi.t is still failinig. I will look at that later...